### PR TITLE
Add Support for SLES 12 and Ubuntu 15.10

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,7 @@ class trusted_ca::params {
       $certs_package = 'ca-certificates'
 
       case $::operatingsystemrelease {
-        '12.04', '14.04', '8.2': {
+        '12.04', '14.04', '8.2', '15.10': {
         }
         default: {
           fail("${::osfamily} ${::operatingsystemrelease} has not been tested with this module.  Please feel free to test and report the results")
@@ -53,7 +53,14 @@ class trusted_ca::params {
           $update_command = 'c_rehash'
           $install_path = '/etc/ssl/certs'
           $certfile_suffix = 'pem'
-          $certs_package = 'openssl-certs'
+          case $::operatingsystemmajrelease {
+            '11': {
+              $certs_package = 'openssl-certs'
+            }
+            default: {
+              $certs_package = 'ca-certificates'
+            }
+          }
         }
         'OpenSuSE': {
           $path = ['/usr/sbin', '/usr/bin']

--- a/metadata.json
+++ b/metadata.json
@@ -12,8 +12,8 @@
     { "operatingsystem": "RedHat", "operatingsystemrelease": [ "6", "7" ] },
     { "operatingsystem": "CentOS", "operatingsystemrelease": [ "6", "7" ] },
     { "operatingsystem": "OpenSuSE", "operatingsystemrelease": [ "13.1" ] },
-    { "operatingsystem": "SLES", "operatingsystemrelease": [ "11" ] },
-    { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "10.04", "12.04", "14.04" ] },
+    { "operatingsystem": "SLES", "operatingsystemrelease": [ "11", "12" ] },
+    { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "10.04", "12.04", "14.04", "15.10" ] },
     { "operatingsystem": "Debain", "operatingsystemrelease": [ "8.2" ] }
   ],
   "dependencies": [


### PR DESCRIPTION
This allows me to make use of the module on SLES12 as well as on Ubuntu 15.10.

SLES currently only supported the 11.X version, therefore I made the case statement specific for that
and defaulted to the value now valid for SLES 12, with the hope, in future it will still match (:

let me know if there is something to change/enhance/etc...